### PR TITLE
fix run the jewels 3 spotify link

### DIFF
--- a/artists.json
+++ b/artists.json
@@ -12593,7 +12593,7 @@
 			"year": "2016",
 			"album": "Run The Jewels 3",
 			"youtube": "vWaljXUiCaE",
-			"spotify": "4RnfMhMUMqHlrn4V6A3KfS",
+			"spotify": "7q1uNF3HT1wTjxuMW0rFJn",
 			"itunes": "id1186542356",
 			"googleplay": "Babd2uvkbuienhcq4vxcbg2qtmq",
 			"amazon": "B01NAJDYUF"


### PR DESCRIPTION
Noticed that the [Run The Jewels spotify album](https://open.spotify.com/album/4RnfMhMUMqHlrn4V6A3KfS) link wasn't working for me.

Replaced with https://open.spotify.com/album/7q1uNF3HT1wTjxuMW0rFJn